### PR TITLE
iOS 9 does not allow arbitary HTTP loads

### DIFF
--- a/samples/Xamarin.Forms/FormsNativeVideoPlayer/iOS/Info.plist
+++ b/samples/Xamarin.Forms/FormsNativeVideoPlayer/iOS/Info.plist
@@ -59,6 +59,23 @@
 	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>www.androidbegin.com</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<false/>
+				<!--Include to allow HTTP requests-->
+				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+				<!--Include to specify minimum TLS version-->
+				<key>NSTemporaryExceptionMinimumTLSVersion</key>
+				<string>TLSv1.1</string>
+			</dict>
+		</dict>
+	</dict>
 </dict>
 </plist>
 


### PR DESCRIPTION
This is needed for the Video Player to be able to load a video from an HTTP connection, which is what the FormsNativeVideoPlayer/iOS project does. 